### PR TITLE
Add Admin Mode with teacher login for register/unregister actions

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,9 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Sign up for activities (teacher login required)
+- Unregister students from activities (teacher login required)
+- Teacher login/logout via top-right user menu
 
 ## Getting Started
 
@@ -48,3 +50,12 @@ The application uses a simple data model with meaningful identifiers:
    - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.
+
+## Teacher Credentials
+
+Teacher usernames/passwords are stored in `src/teachers.json`.
+
+Sample credentials:
+
+- `teacher.alex` / `teach123`
+- `teacher.sam` / `teach456`

--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,44 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Header, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+import secrets
+from pydantic import BaseModel
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+teachers_file = Path(__file__).parent / "teachers.json"
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def load_teachers():
+    with teachers_file.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+# In-memory token sessions for teacher logins.
+teacher_sessions = {}
+
+
+def require_teacher(authorization: str | None):
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    token = authorization.split(" ", 1)[1]
+    username = teacher_sessions.get(token)
+    if not username:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    return username
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -88,9 +118,46 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def login(payload: LoginRequest):
+    teachers = load_teachers()
+    teacher = next(
+        (
+            t
+            for t in teachers
+            if t["username"] == payload.username and t["password"] == payload.password
+        ),
+        None,
+    )
+
+    if not teacher:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(32)
+    teacher_sessions[token] = payload.username
+    return {"token": token, "username": payload.username}
+
+
+@app.get("/auth/me")
+def auth_me(authorization: str | None = Header(default=None)):
+    username = require_teacher(authorization)
+    return {"username": username, "role": "teacher"}
+
+
+@app.post("/auth/logout")
+def logout(authorization: str | None = Header(default=None)):
+    username = require_teacher(authorization)
+    token = authorization.split(" ", 1)[1]
+    teacher_sessions.pop(token, None)
+    return {"message": f"Logged out {username}"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str,
+                        authorization: str | None = Header(default=None)):
     """Sign up a student for an activity"""
+    require_teacher(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -105,14 +172,23 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is full"
+        )
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str,
+                             authorization: str | None = Header(default=None)):
     """Unregister a student from an activity"""
+    require_teacher(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,56 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userMenuButton = document.getElementById("user-menu-button");
+  const userMenu = document.getElementById("user-menu");
+  const authStatus = document.getElementById("auth-status");
+  const loginMenuButton = document.getElementById("login-menu-button");
+  const logoutMenuButton = document.getElementById("logout-menu-button");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const cancelLoginButton = document.getElementById("cancel-login-button");
+
+  let authToken = localStorage.getItem("teacherToken") || "";
+  let authUsername = localStorage.getItem("teacherUsername") || "";
+
+  function authHeaders() {
+    return authToken ? { Authorization: `Bearer ${authToken}` } : {};
+  }
+
+  function setAuthUi() {
+    const isLoggedIn = Boolean(authToken);
+    authStatus.textContent = isLoggedIn ? `Logged in: ${authUsername}` : "Not logged in";
+    loginMenuButton.classList.toggle("hidden", isLoggedIn);
+    logoutMenuButton.classList.toggle("hidden", !isLoggedIn);
+
+    signupForm.querySelectorAll("input, select, button[type='submit']").forEach((el) => {
+      el.disabled = !isLoggedIn;
+    });
+  }
+
+  async function validateSession() {
+    if (!authToken) {
+      setAuthUi();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", { headers: authHeaders() });
+      if (!response.ok) {
+        throw new Error("Session invalid");
+      }
+      const result = await response.json();
+      authUsername = result.username;
+      localStorage.setItem("teacherUsername", authUsername);
+    } catch (error) {
+      authToken = "";
+      authUsername = "";
+      localStorage.removeItem("teacherToken");
+      localStorage.removeItem("teacherUsername");
+    }
+
+    setAuthUi();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +62,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +81,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        authToken
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -80,6 +135,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: authHeaders(),
         }
       );
 
@@ -124,6 +180,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: authHeaders(),
         }
       );
 
@@ -155,6 +212,79 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  userMenuButton.addEventListener("click", () => {
+    userMenu.classList.toggle("hidden");
+  });
+
+  loginMenuButton.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    userMenu.classList.add("hidden");
+  });
+
+  cancelLoginButton.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("teacher-username").value;
+    const password = document.getElementById("teacher-password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result.detail || "Login failed");
+      }
+
+      authToken = result.token;
+      authUsername = result.username;
+      localStorage.setItem("teacherToken", authToken);
+      localStorage.setItem("teacherUsername", authUsername);
+      setAuthUi();
+      loginModal.classList.add("hidden");
+      loginForm.reset();
+
+      messageDiv.textContent = `Welcome, ${authUsername}`;
+      messageDiv.className = "success";
+      messageDiv.classList.remove("hidden");
+      fetchActivities();
+    } catch (error) {
+      messageDiv.textContent = error.message || "Login failed";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+    }
+  });
+
+  logoutMenuButton.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", { method: "POST", headers: authHeaders() });
+    } catch (error) {
+      console.error("Logout request failed:", error);
+    }
+
+    authToken = "";
+    authUsername = "";
+    localStorage.removeItem("teacherToken");
+    localStorage.removeItem("teacherUsername");
+    setAuthUi();
+    userMenu.classList.add("hidden");
+    fetchActivities();
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!userMenu.contains(event.target) && !userMenuButton.contains(event.target)) {
+      userMenu.classList.add("hidden");
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  validateSession().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,16 @@
   </head>
   <body>
     <header>
+      <div class="user-controls">
+        <button id="user-menu-button" class="user-icon-button" type="button" aria-label="User menu">
+          <span class="user-icon">&#128100;</span>
+        </button>
+        <div id="user-menu" class="user-menu hidden">
+          <p id="auth-status">Not logged in</p>
+          <button id="login-menu-button" type="button">Login</button>
+          <button id="logout-menu-button" type="button" class="hidden">Logout</button>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -23,6 +33,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="teacher-only-note" class="info-note">
+          Only logged-in teachers can register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -40,6 +53,26 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-content">
+        <h3 id="login-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Sign In</button>
+            <button id="cancel-login-button" type="button" class="secondary-button">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <footer>
       <p>&copy; 2026 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,69 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+.user-controls {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.user-icon-button {
+  background-color: #ffffff;
+  color: #1a237e;
+  border-radius: 999px;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.user-icon-button:hover {
+  background-color: #e8eaf6;
+}
+
+.user-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.user-menu {
+  position: absolute;
+  top: 46px;
+  right: 0;
+  width: 210px;
+  background: #ffffff;
+  color: #333;
+  border-radius: 8px;
+  padding: 12px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+  z-index: 20;
+}
+
+.user-menu p {
+  margin-bottom: 10px;
+  font-size: 14px;
+}
+
+.user-menu button {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.info-note {
+  margin-bottom: 15px;
+  color: #455a64;
+  font-size: 14px;
 }
 
 header h1 {
@@ -182,6 +239,40 @@ button:hover {
   border: 1px solid #ef9a9a;
 }
 
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 420px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.secondary-button {
+  background-color: #eceff1;
+  color: #37474f;
+}
+
+.secondary-button:hover {
+  background-color: #dfe5e8;
+}
+
 .info {
   background-color: #d1ecf1;
   color: #0c5460;
@@ -190,6 +281,21 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+@media (max-width: 640px) {
+  .user-controls {
+    top: 8px;
+    right: 8px;
+  }
+
+  .user-menu {
+    width: 190px;
+  }
+
+  .modal-content {
+    margin: 0 12px;
+  }
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,10 @@
+[
+  {
+    "username": "teacher.alex",
+    "password": "teach123"
+  },
+  {
+    "username": "teacher.sam",
+    "password": "teach456"
+  }
+]


### PR DESCRIPTION
## Summary
Implements issue #5 by adding an Admin Mode where only logged-in teachers can register and unregister students.

## Changes
- Added backend authentication endpoints:
  - `POST /auth/login`
  - `GET /auth/me`
  - `POST /auth/logout`
- Added bearer-token protection for:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Added teacher credential source in `src/teachers.json`.
- Added UI user menu in the top-right with login/logout controls.
- Added teacher login modal and token-based session handling in frontend.
- Disabled signup form unless a teacher is logged in.
- Hid unregister buttons for non-logged-in users.
- Updated docs with feature behavior and sample credentials.

## Notes
- Student users can still view all activities and current participants.
- This keeps credentials in JSON as requested by the issue context.

Closes #5